### PR TITLE
Fix Windows "large function" crash

### DIFF
--- a/llvmexpr/jit/Compiler.cpp
+++ b/llvmexpr/jit/Compiler.cpp
@@ -137,6 +137,9 @@ CompiledFunction Compiler::compile_with_approx_math(int actual_approx_math) {
     if (FMF.allowReciprocal()) {
         FuncAttrs.addAttribute("allow-reciprocal-fp-math", "true");
     }
+#ifdef _WIN32
+    FuncAttrs.addAttribute("no-stack-arg-probe", "true");
+#endif
     FuncAttrs.addAttribute(llvm::Attribute::NoUnwind);
     FuncAttrs.addAttribute(llvm::Attribute::WillReturn);
     func->addFnAttrs(FuncAttrs);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add Windows-specific "no-stack-arg-probe" attribute to disable stack probing and prevent large function crashes